### PR TITLE
Promt for a reason and add it as a note before canceling the subscription

### DIFF
--- a/wcs-cancel-subscription-confirmation.js
+++ b/wcs-cancel-subscription-confirmation.js
@@ -1,8 +1,29 @@
 jQuery(document).ready(function($) {
-  $('.button.cancel').click(function(e) {
-    var confirmDelete = window.confirm("Are you sure you want to cancel your subscription?")
-    if (!confirmDelete) {
-      e.preventDefault()
-    }
-  });
+	$('.button.cancel').click(function(e) {
+		var cancelURL = jQuery(this).attr("href");
+		var subscription_id = $.urlParam('subscription_id', cancelURL);
+
+		var confirmDelete = prompt(ajax_object.promt_msg, "");
+		if (confirmDelete == null || confirmDelete == "") {
+			e.preventDefault();
+		} else {
+			var data = {
+				'action': 'wcs_cancel_confirmation',
+				'subscription_id': subscription_id,
+				'reason_to_cancel': confirmDelete
+			};
+
+			jQuery.post(ajax_object.ajax_url, data, function(response) {
+				if(response=='' || response==null || response<=0){
+					alert(ajax_object.error_msg);
+					e.preventDefault();
+				}
+			});
+		}
+	});
 })
+
+jQuery.urlParam = function(name, url) {
+	var results = new RegExp('[\?&]' + name + '=([^&#]*)').exec(url);
+	return results[1] || 0;
+}

--- a/wcs-cancel-subscription-confirmation.php
+++ b/wcs-cancel-subscription-confirmation.php
@@ -32,12 +32,36 @@
 */
 
 function wcs_cancel_subscription_confirmation() {
-    if ( ! function_exists( 'is_account_page' ) ) {
-        return;
-    }
-     
-    if ( is_account_page() ) {
-        wp_enqueue_script( 'wcs-cancel-subscription-confirmation-script', plugin_dir_url( __FILE__ ) . 'wcs-cancel-subscription-confirmation.js', array( 'jquery' ), '1.0.0', true  );
+	if ( ! function_exists( 'is_account_page' ) ) {
+		return;
+	}
+
+	if ( is_account_page() ) {
+		wp_register_script( 'wcs-cancel-subscription-confirmation-script', plugin_dir_url( __FILE__ ) . 'wcs-cancel-subscription-confirmation.js', array( 'jquery' ), '1.0.0', true );
+		$script_atts = array(
+			'ajax_url' => admin_url( 'admin-ajax.php' ),
+			'promt_msg' => apply_filters( "wcs_cancel_confirmation_promt_msg", __("Are you sure you want to cancel your subscription?\nIf so, please type the reason why you want to cancel it here:","wcs-cancel-confirmation" ) ) ,
+			'error_msg' => apply_filters( "wcs_cancel_confirmation_error_msg", __("There has been an error when saving the cancelation reason. Please try again.","wcs-cancel-confirmation" ) )
+		);
+		wp_localize_script( 'wcs-cancel-subscription-confirmation-script', 'ajax_object', $script_atts );
+		wp_enqueue_script( 'wcs-cancel-subscription-confirmation-script' );
     }
 }
 add_action( 'wp_enqueue_scripts', 'wcs_cancel_subscription_confirmation' );
+
+
+function wcs_cancel_confirmation() {
+	$subscription_id = intval( $_POST['subscription_id'] );
+	$reason_to_cancel = sanitize_text_field( $_POST['reason_to_cancel'] );
+
+	$subscription = wc_get_order( $subscription_id );
+
+	$note_id = $subscription->add_order_note( apply_filters( "wcs_cancel_confirmation_note_header", __( "Reason to Cancel:", "wcs-cancel-confirmation" ) )."<br /><b><i>".$reason_to_cancel."</i></b>" );
+
+	$subscription->save();
+
+	echo $note_id;
+
+    wp_die(); 
+}
+add_action( 'wp_ajax_wcs_cancel_confirmation', 'wcs_cancel_confirmation' );

--- a/wcs-cancel-subscription-confirmation.php
+++ b/wcs-cancel-subscription-confirmation.php
@@ -35,8 +35,10 @@ function wcs_cancel_subscription_confirmation() {
 	if ( ! function_exists( 'is_account_page' ) ) {
 		return;
 	}
-
-	if ( is_account_page() ) {
+	
+	$cancel_confirmation_required = apply_filters( 'wcs_cancel_confirmation_promt_enabled', ( 'yes' == get_option( "wcs-cancel-confirmation", 'no' ) ) ? true : false );
+	
+	if ( is_account_page() && 'yes' == $cancel_confirmation_required ) {
 		wp_register_script( 'wcs-cancel-subscription-confirmation-script', plugin_dir_url( __FILE__ ) . 'wcs-cancel-subscription-confirmation.js', array( 'jquery' ), '1.0.0', true );
 		$script_atts = array(
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
@@ -65,3 +67,23 @@ function wcs_cancel_confirmation() {
     wp_die(); 
 }
 add_action( 'wp_ajax_wcs_cancel_confirmation', 'wcs_cancel_confirmation' );
+
+
+function add_cancelation_settings( $settings ) {
+
+	$misc_section_end = wp_list_filter( $settings, array( 'id' => 'woocommerce_subscriptions_miscellaneous', 'type' => 'sectionend' ) );
+
+	$spliced_array = array_splice( $settings, key( $misc_section_end ), 0, array(
+		array(
+			'name'     => __( 'Ask for the cancelation reason', 'wcs-cancel-confirmation' ),
+			'desc'     => __( 'Promt the customer for a cancelation reason', 'wcs-cancel-confirmation' ),
+			'id'       => 'wcs-cancel-confirmation',
+			'default'  => 'no',
+			'type'     => 'checkbox',
+			'desc_tip' =>  __( 'Ask for the cancelation reason when the customer cancels a subscription from My account page. The provided reason will be added as a subscription note in the backend.' ),
+		),
+	) );
+
+	return $settings;
+}
+add_filter( 'woocommerce_subscription_settings', 'add_cancelation_settings'  );

--- a/wcs-cancel-subscription-confirmation.php
+++ b/wcs-cancel-subscription-confirmation.php
@@ -43,7 +43,7 @@ function wcs_cancel_subscription_confirmation() {
 		$script_atts = array(
 			'ajax_url' => admin_url( 'admin-ajax.php' ),
 			'promt_msg' => apply_filters( "wcs_cancel_confirmation_promt_msg", __("Are you sure you want to cancel your subscription?\nIf so, please type the reason why you want to cancel it here:","wcs-cancel-confirmation" ) ) ,
-			'error_msg' => apply_filters( "wcs_cancel_confirmation_error_msg", __("There has been an error when saving the cancelation reason. Please try again.","wcs-cancel-confirmation" ) )
+			'error_msg' => apply_filters( "wcs_cancel_confirmation_error_msg", __("There has been an error when saving the cancellation reason. Please try again.","wcs-cancel-confirmation" ) )
 		);
 		wp_localize_script( 'wcs-cancel-subscription-confirmation-script', 'ajax_object', $script_atts );
 		wp_enqueue_script( 'wcs-cancel-subscription-confirmation-script' );
@@ -58,7 +58,7 @@ function wcs_cancel_confirmation() {
 
 	$subscription = wc_get_order( $subscription_id );
 
-	$note_id = $subscription->add_order_note( apply_filters( "wcs_cancel_confirmation_note_header", __( "Reason to Cancel:", "wcs-cancel-confirmation" ) )."<br /><b><i>".$reason_to_cancel."</i></b>" );
+	$note_id = $subscription->add_order_note( apply_filters( "wcs_cancel_confirmation_note_header", __( "Cancellation Reason:", "wcs-cancel-confirmation" ) )."<br /><b><i>".$reason_to_cancel."</i></b>" );
 
 	$subscription->save();
 
@@ -75,12 +75,12 @@ function add_cancelation_settings( $settings ) {
 
 	$spliced_array = array_splice( $settings, key( $misc_section_end ), 0, array(
 		array(
-			'name'     => __( 'Ask for the cancelation reason', 'wcs-cancel-confirmation' ),
-			'desc'     => __( 'Promt the customer for a cancelation reason', 'wcs-cancel-confirmation' ),
+			'name'     => __( 'Ask for the cancellation reason', 'wcs-cancel-confirmation' ),
+			'desc'     => __( 'Prompt the customer for a cancellation reason', 'wcs-cancel-confirmation' ),
 			'id'       => 'wcs-cancel-confirmation',
 			'default'  => 'no',
 			'type'     => 'checkbox',
-			'desc_tip' =>  __( 'Ask for the cancelation reason when the customer cancels a subscription from My account page. The provided reason will be added as a subscription note in the backend.' ),
+			'desc_tip' =>  __( 'Ask for the cancellation reason when the customer cancels a subscription from the My Account page. The provided reason will be added as a subscription note in the backend.' ),
 		),
 	) );
 


### PR DESCRIPTION
Fixes #2 

### Description
I've changed the confirm dialog with a promt to ask the customer for a cancelation reason before canceling the subscription.

When the customer adds the cancelation note and accepts to cancel the subscription, the reason is stored as a subscription note on the backend to make the administrator able to find what motivated the customer to cancel the subscription. 

### Screenshots

![image](https://user-images.githubusercontent.com/1201868/42169153-35ea0fe6-7e13-11e8-887a-67ce8acd4e06.png)
https://cl.ly/1J2A450m2k0h

![image](https://user-images.githubusercontent.com/1201868/42169172-3f04bb6c-7e13-11e8-85d9-e0ce1c13b62a.png)
https://cl.ly/461w0J411C0z