### PR TITLE
Added Setting & cancellation confirmation for Cancel

### DIFF
--- a/wcs-cancel-subscription-confirmation.js
+++ b/wcs-cancel-subscription-confirmation.js
@@ -1,24 +1,37 @@
 jQuery(document).ready(function($) {
+
 	$('.button.cancel').click(function(e) {
 		e.preventDefault();
 		var cancelURL = jQuery(this).attr("href");
-		var subscription_id = $.urlParam('subscription_id', cancelURL);
 
-		var confirmDelete = prompt(ajax_object.promt_msg, "");
-		if (confirmDelete != null && confirmDelete != "") {
-			var data = {
-				'action': 'wcs_cancel_confirmation',
-				'subscription_id': subscription_id,
-				'reason_to_cancel': confirmDelete
-			};
+		if(1 == ajax_object.reason_required)
+		{
+			var subscription_id = $.urlParam('subscription_id', cancelURL);
 
-			jQuery.post(ajax_object.ajax_url, data, function(response) {
-				if(response=='' || response==null || response<=0){
-					alert(ajax_object.error_msg);
-				}
-			}).done(function() {
+			var confirmDelete = prompt(ajax_object.promt_msg, "");
+			if (confirmDelete != null && confirmDelete != "") {
+				var data = {
+					'action': 'wcs_cancel_confirmation',
+					'subscription_id': subscription_id,
+					'reason_to_cancel': confirmDelete
+				};
+	
+				jQuery.post(ajax_object.ajax_url, data, function(response) {
+					if(response=='' || response==null || response<=0){
+						alert(ajax_object.error_msg);
+					}
+				}).done(function() {
+					window.location.href = cancelURL;
+				});
+			}
+		}
+		else
+		{
+			var confirmCancel = confirm(ajax_object.promt_msg);
+			if(confirmCancel == true)
+			{
 				window.location.href = cancelURL;
-			});
+			}	
 		}
 	});
 })

--- a/wcs-cancel-subscription-confirmation.php
+++ b/wcs-cancel-subscription-confirmation.php
@@ -39,7 +39,13 @@ function wcs_cancel_subscription_confirmation()
         return;
     }
     
-    $cancel_confirmation_required = apply_filters('wcs_cancel_confirmation_promt_enabled', ('yes' == get_option("wcs-ask-confirmation", 'no')) ? true : false);
+    $cancel_confirm_setting = false;
+    
+    if (('yes' == get_option("wcs-ask-confirmation", 'no')) || ('yes' == get_option('wcs-cancel-confirmation', 'no'))) {
+        $cancel_confirm_setting = true;
+    }
+    
+    $cancel_confirmation_required = apply_filters('wcs_cancel_confirmation_promt_enabled', $cancel_confirm_setting);
     
     if (is_account_page() && 'yes' == $cancel_confirmation_required) {
         wp_register_script('wcs-cancel-subscription-confirmation-script', plugin_dir_url(__FILE__) . 'wcs-cancel-subscription-confirmation.js', array( 'jquery' ), '1.0.0', true);

--- a/wcs-cancel-subscription-confirmation.php
+++ b/wcs-cancel-subscription-confirmation.php
@@ -33,59 +33,87 @@
 * @since		1.0
 */
 
-function wcs_cancel_subscription_confirmation() {
-	if ( ! function_exists( 'is_account_page' ) ) {
-		return;
-	}
-	
-	$cancel_confirmation_required = apply_filters( 'wcs_cancel_confirmation_promt_enabled', ( 'yes' == get_option( "wcs-cancel-confirmation", 'no' ) ) ? true : false );
-	
-	if ( is_account_page() && 'yes' == $cancel_confirmation_required ) {
-		wp_register_script( 'wcs-cancel-subscription-confirmation-script', plugin_dir_url( __FILE__ ) . 'wcs-cancel-subscription-confirmation.js', array( 'jquery' ), '1.0.0', true );
-		$script_atts = array(
-			'ajax_url' => admin_url( 'admin-ajax.php' ),
-			'promt_msg' => apply_filters( "wcs_cancel_confirmation_promt_msg", __("Are you sure you want to cancel your subscription?\nIf so, please type the reason why you want to cancel it here:","wcs-cancel-confirmation" ) ) ,
-			'error_msg' => apply_filters( "wcs_cancel_confirmation_error_msg", __("There has been an error when saving the cancellation reason. Please try again.","wcs-cancel-confirmation" ) )
-		);
-		wp_localize_script( 'wcs-cancel-subscription-confirmation-script', 'ajax_object', $script_atts );
-		wp_enqueue_script( 'wcs-cancel-subscription-confirmation-script' );
+function wcs_cancel_subscription_confirmation()
+{
+    if (! function_exists('is_account_page')) {
+        return;
+    }
+    
+    $cancel_confirmation_required = apply_filters('wcs_cancel_confirmation_promt_enabled', ('yes' == get_option("wcs-ask-confirmation", 'no')) ? true : false);
+    
+    if (is_account_page() && 'yes' == $cancel_confirmation_required) {
+        wp_register_script('wcs-cancel-subscription-confirmation-script', plugin_dir_url(__FILE__) . 'wcs-cancel-subscription-confirmation.js', array( 'jquery' ), '1.0.0', true);
+        
+        if ('yes' == get_option('wcs-cancel-confirmation', 'no')) {
+            $promt_msg = apply_filters("wcs_cancel_confirmation_promt_msg", __("Are you sure you want to cancel your subscription?\nIf so, please type the reason why you want to cancel it here:", "wcs-cancel-confirmation"));
+
+            $reason_required = true;
+        } else {
+            $promt_msg = apply_filters("wcs_cancel_confirmation_promt_msg", __("Are you sure you want to cancel your subscription?", "wcs-cancel-confirmation"));
+
+            $reason_required = false;
+        }
+
+        $script_atts = array(
+            'ajax_url' => admin_url('admin-ajax.php'),
+            'promt_msg' => $promt_msg ,
+            'error_msg' => apply_filters("wcs_cancel_confirmation_error_msg", __("There has been an error when saving the cancellation reason. Please try again.", "wcs-cancel-confirmation")),
+            'reason_required' => $reason_required,
+        );
+        wp_localize_script('wcs-cancel-subscription-confirmation-script', 'ajax_object', $script_atts);
+        wp_enqueue_script('wcs-cancel-subscription-confirmation-script');
     }
 }
-add_action( 'wp_enqueue_scripts', 'wcs_cancel_subscription_confirmation' );
+add_action('wp_enqueue_scripts', 'wcs_cancel_subscription_confirmation');
 
 
-function wcs_cancel_confirmation() {
-	$subscription_id = intval( $_POST['subscription_id'] );
-	$reason_to_cancel = sanitize_text_field( $_POST['reason_to_cancel'] );
+function wcs_cancel_confirmation()
+{
+    $subscription_id = intval($_POST['subscription_id']);
+    $reason_to_cancel = sanitize_text_field($_POST['reason_to_cancel']);
 
-	$subscription = wc_get_order( $subscription_id );
+    $subscription = wc_get_order($subscription_id);
 
-	$note_id = $subscription->add_order_note( apply_filters( "wcs_cancel_confirmation_note_header", __( "Cancellation Reason:", "wcs-cancel-confirmation" ) )."<br /><b><i>".$reason_to_cancel."</i></b>" );
+    $note_id = $subscription->add_order_note(apply_filters("wcs_cancel_confirmation_note_header", __("Cancellation Reason:", "wcs-cancel-confirmation"))."<br /><b><i>".$reason_to_cancel."</i></b>");
 
-	$subscription->save();
+    $subscription->save();
 
-	echo $note_id;
+    echo $note_id;
 
-    wp_die(); 
+    wp_die();
 }
-add_action( 'wp_ajax_wcs_cancel_confirmation', 'wcs_cancel_confirmation' );
+add_action('wp_ajax_wcs_cancel_confirmation', 'wcs_cancel_confirmation');
 
 
-function add_cancelation_settings( $settings ) {
+function add_cancelation_settings($settings)
+{
+    $misc_section_end = wp_list_filter($settings, array( 'id' => 'woocommerce_subscriptions_miscellaneous', 'type' => 'sectionend' ));
 
-	$misc_section_end = wp_list_filter( $settings, array( 'id' => 'woocommerce_subscriptions_miscellaneous', 'type' => 'sectionend' ) );
+    $spliced_array = array_splice($settings, key($misc_section_end), 0, array(
 
-	$spliced_array = array_splice( $settings, key( $misc_section_end ), 0, array(
-		array(
-			'name'     => __( 'Ask for the cancellation reason', 'wcs-cancel-confirmation' ),
-			'desc'     => __( 'Prompt the customer for a cancellation reason', 'wcs-cancel-confirmation' ),
-			'id'       => 'wcs-cancel-confirmation',
-			'default'  => 'no',
-			'type'     => 'checkbox',
-			'desc_tip' =>  __( 'Ask for the cancellation reason when the customer cancels a subscription from the My Account page. The provided reason will be added as a subscription note in the backend.' ),
-		),
-	) );
+        array(
+            'name'     		  => __('Ask to confirm on cancellation', 'wcs-cancel-confirmation'),
+            'desc'            => __('Ask for Cancel confirmation', 'wcs-cancel-confirmation'),
+            'id'              => 'wcs-ask-confirmation',
+            'default'         => 'no',
+            'type'            => 'checkbox',
+            'desc_tip'        => __('Ask for the confirmation when the customer cancels a subscription from the My Account page.'),
+            'checkboxgroup'   => 'start',
+            'show_if_checked' => 'option',
+        ),
 
-	return $settings;
+        array(
+            'desc'     => __('Prompt the customer for a cancellation reason', 'wcs-cancel-confirmation'),
+            'id'       => 'wcs-cancel-confirmation',
+            'default'  => 'no',
+            'type'     => 'checkbox',
+            'desc_tip' =>  __('Ask for the cancellation reason when the customer cancels a subscription from the My Account page. The provided reason will be added as a subscription note in the backend.'),
+            'checkboxgroup'   => 'end',
+            'show_if_checked' => 'yes',
+        ),
+
+    ));
+
+    return $settings;
 }
-add_filter( 'woocommerce_subscription_settings', 'add_cancelation_settings'  );
+add_filter('woocommerce_subscription_settings', 'add_cancelation_settings');


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Added Setting 'Ask for Cancel confirmation' to enable asking confirmation on 'Cancel' subscription button without collecting the reason. Admin can choose to ask for Reason or just set to confirm from the customer regarding the Subscription cancellation request. 

### How to test the changes in this Pull Request:

**Scenario 1** 

1. - Enable 'Ask for Cancel confirmation' setting.
2. - It will display another setting 'Prompt the customer for a cancellation reason' on click of the previous setting. Enable it as well. 
3. - Try cancelling subscription from My Account --> Subscription screen, it will ask for a reason for cancellation.

**Scenario 2**

1. Enable 'Ask for Cancel confirmation' setting.
2. Disable the Reason 'Prompt the customer for a cancellation reason'. 
3. Try cancelling subscription from My Account --> Subscription screen, it will ask the customer to confirm whether to proceed with cancellation or not. 

**Scenario 3**

1. Disable all setting
2. Try cancelling subscription from My Account --> Subscription screen, Subscription will get cancelled directly.

### Other information:

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Tested changes on the local system.
- [x] Provided solution for [Issue 7](https://github.com/Prospress/woocommerce-subscriptions-cancel-subscription-confirmation/issues/7)

### Changelog entry
Settings added to just enable confirmation on subscription cancellation. 